### PR TITLE
add support for automatic end of line detection in Prettier to avoid warnings on Windows

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,9 @@ module.exports = {
     'plugin:prettier/recommended',
   ],
   rules: {
-    'prettier/prettier': 'warn',
+    'prettier/prettier': ['warn', {
+      endOfLine: 'auto',
+    }],
     'node/no-missing-import': 'off',
     'node/no-empty-function': 'off',
     'node/no-unsupported-features/es-syntax': 'off',


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

For historical reasons, the line breaks of the text file on windows and Linux are different.

- Windows At the time of line break, carriage return is used at the same time CR(carriage-return character) and line breaks LF (linefeed character)
- Mac and Linux only use the newline character LF
- Old version of Mac uses carriage return CR

Therefore, there will be incompatibility problems when text files are created and used in different systems.

This happened to me because I'm on a Windows computer, but the code was generated on a Mac or Linux computer.

With the present change, Prettier will try to determine the appropriate line ending style (e.g., LF or CRLF) based on the current file or the environment. It helps maintain consistent line endings across different platforms and operating systems.

I hope this helps making contributing to the project from Windows easier.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
